### PR TITLE
fix Quire #144: cut tool doesn't split polygons

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "main": "dist/leaflet.pm.min.js",
   "dependencies": {
-    "@turf/difference": "^6.0.2",
+    "@turf/difference": "5.1.5",
     "@turf/intersect": "^6.1.3",
     "@turf/kinks": "6.x",
     "lodash": "^4.17.15"

--- a/src/js/Draw/L.PM.Draw.Cut.js
+++ b/src/js/Draw/L.PM.Draw.Cut.js
@@ -33,7 +33,7 @@ Draw.Cut = Draw.Polygon.extend({
 
     // loop through all layers that intersect with the drawn (cutting) layer
     layers.forEach((l) => {
-      const diff = difference(l.toGeoJSON(100), layer.toGeoJSON(100));
+      const diff = difference(l.toGeoJSON(15), layer.toGeoJSON(15));
 
       // the resulting layer after the cut
       const resultingLayer = L.geoJSON(diff, l.options);


### PR DESCRIPTION
https://quire.io/w/site-dev/144/Cut_Tool_Cut_acti...?board=current&filter=all.
Cut Tool: Cut action works properly but will not split the polygons. Keeps it as one polygon in the layer field